### PR TITLE
use status() in probe to return ocf.OCF_NOT_RUNNING

### DIFF
--- a/ra/SAPStartSrv.in
+++ b/ra/SAPStartSrv.in
@@ -268,7 +268,7 @@ class SapStartSrv(object):
         '''
         self._inititialize()
         if ocf.is_probe():
-            return self._get_status().returncode
+            return self.status()
         return ocf.OCF_SUCCESS
 
     def validate(self):


### PR DESCRIPTION
When probing and no sapstartsrv is running, we want to return OCF_NOT_RUNNING.
If we do not do this, the resource "runs twice" on both sides of the cluster.