### PR TITLE
Fix github actions coverage command

### DIFF
--- a/.github/workflows/package-ci.yml
+++ b/.github/workflows/package-ci.yml
@@ -27,14 +27,16 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tox tox-gh-actions
-    - name: Test with tox
-      run: tox
+        pip install pytest pytest-cov mock
+    - name: Test with pytest
+      run: py.test -vv --cov=SAPStartSrv --cov-config .coveragerc --cov-report term --cov-report xml tests
     - name: Publish code coverage
       uses: paambaati/codeclimate-action@v2.7.5
       if: env.CC_TEST_REPORTER_ID != null
       env:
         CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+      with:
+        coverageLocations: coverage.xml:coverage.py
 
   delivery:
     needs: unit-tests

--- a/tox.ini
+++ b/tox.ini
@@ -21,4 +21,4 @@ deps =
     mock
 
 commands =
-    py.test -vv --cov=SAPStartSrv --cov-config ../.coveragerc --cov-report term --cov-report xml
+    py.test -vv --cov=SAPStartSrv --cov-config .coveragerc --cov-report term --cov-report xml


### PR DESCRIPTION
Changing to `pytest` in the CI instead of tox, as tox gives errors uploading the coverage file to codeclimate.