### PR TITLE
Fix spec file to correctly submit in SLE

### DIFF
--- a/sapstartsrv-resource-agents.changes
+++ b/sapstartsrv-resource-agents.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Mar  5 08:54:12 UTC 2021 - Xabier Arbulu <xarbulu@suse.com>
+
+- Fix the spec file to follow properly the SLE submission policies 
+
+-------------------------------------------------------------------
 Fri Dec  4 15:22:52 UTC 2020 - Fabian Herschel <fabian.herschel@suse.com>
 
 - Add sapservices-move script 

--- a/sapstartsrv-resource-agents.spec
+++ b/sapstartsrv-resource-agents.spec
@@ -87,16 +87,10 @@ pytest tests
 
 %files
 %defattr(-,root,root)
-%if 0%{?sle_version:1} && 0%{?sle_version} < 120300
-%doc README.md LICENSE
-%doc %{_mandir}/man7/*.7.gz
-%doc %{_mandir}/man8/*.8.gz
-%else
 %doc README.md
-%doc %{_mandir}/man7/*.7.gz
-%doc %{_mandir}/man8/*.8.gz
 %license LICENSE
-%endif
+%{_mandir}/man7/*.7.gz
+%{_mandir}/man8/*.8.gz
 %dir %{ocf_dir}
 %dir %{ocf_dir}/resource.d
 %defattr(755,root,root,-)


### PR DESCRIPTION
Fix errors in spec file to submit to SLE.
Errors based in:
https://build.suse.de/request/show/237388

> You don't build for < SLE12-SP3 so please remove the if and just use %license, second we don't mark man pages as %doc, please fix that too. Thanks!