### PR TITLE
bsc#1183969 - prevent sapping.service from running a second time after a corosync

### DIFF
--- a/service/sapping.service
+++ b/service/sapping.service
@@ -10,4 +10,4 @@ StandardOutput=syslog
 StandardError=syslog
 
 [Install]
-WantedBy=multi-user.target pacemaker.service
+WantedBy=multi-user.target


### PR DESCRIPTION
start/restart