### PR TITLE
fix for bsc#1185152 and some additional systemd related changes in spec file

### DIFF
--- a/sapstartsrv-resource-agents.changes
+++ b/sapstartsrv-resource-agents.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Apr 22 13:05:47 UTC 2021 - abriel@suse.com
+
+- remove deprecated option "syslog" from the sapping.service and
+  sappong.service files.
+  (bsc#1185152)
+
+-------------------------------------------------------------------
 Wed Mar 31 09:43:09 UTC 2021 - abriel@suse.com
 
 - prevent sapping.service from running a second time after a
@@ -18,4 +25,8 @@ Fri Dec  4 15:22:52 UTC 2020 - Fabian Herschel <fabian.herschel@suse.com>
 -------------------------------------------------------------------
 Wed Sep 16 09:33:32 UTC 2020 - Xabier Arbulu <xarbulu@suse.com>
 
+- Simplified Cluster FS architecture for S/4HANA and NetWeaver
+  It controls the instance specific sapstartsrv process which
+  provides the API to start, stop and check a SAP instance.
+  (jsc#ECO-3341, jsc#SLE-16935, jsc#SLE-17440)
 - Include python version to the resource agent 

--- a/sapstartsrv-resource-agents.spec
+++ b/sapstartsrv-resource-agents.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package sapstartsrv-resource-agents
 #
-# Copyright (c) 2020 SUSE LLC.
+# Copyright (c) 2020-2021 SUSE LLC.
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -23,22 +23,16 @@
 Name:           sapstartsrv-resource-agents
 License:        GPL-2.0
 Group:          Productivity/Clustering/HA
-AutoReqProv:    on
 Summary:        Resource agent for SAP instance specific sapstartsrv service
 Version:        0
 Release:        0
-Url:            https://github.com/SUSE/SAPStartSrv-resourceAgent
-
-BuildArch:      noarch
-
+URL:            https://github.com/SUSE/SAPStartSrv-resourceAgent
 Source0:        %{name}-%{version}.tar.gz
-
-BuildRoot:      %{_tmppath}/%{name}-%{version}-build
-
-Requires:       pacemaker > 1.1.1
-Requires:       resource-agents
-Requires:       python3
+BuildArch:      noarch
 BuildRequires:  resource-agents
+Requires:       resource-agents
+Requires:       pacemaker > 1.1.1
+Requires:       python3
 %if %{with test}
 BuildRequires:  python3-mock
 BuildRequires:  python3-pytest
@@ -46,7 +40,7 @@ BuildRequires:  python3-pytest
 
 %define raname SAPStartSrv
 %define srvname sapservices-move
-%define ocf_dir /usr/lib/ocf
+%define ocf_dir %{_prefix}/lib/ocf
 
 %description
 This is a resource agent for the instance specific SAP start framework.
@@ -66,17 +60,17 @@ Authors:
 gzip man/*
 
 %install
-mkdir -p %{buildroot}%{ocf_dir}/resource.d/suse
-mkdir -p %{buildroot}%{_mandir}/man7
-mkdir -p %{buildroot}%{_mandir}/man8
-mkdir -p %{buildroot}%{_sbindir}
-mkdir -p %{buildroot}%{_unitdir}
-
-install -m 0755 ra/%{raname}.in %{buildroot}%{ocf_dir}/resource.d/suse/%{raname}
+install -D -m 0755 ra/%{raname}.in %{buildroot}%{ocf_dir}/resource.d/suse/%{raname}
+install -d %{buildroot}%{_mandir}/man7
+install -d %{buildroot}%{_mandir}/man8
 install -m 0444 man/*.7.gz %{buildroot}%{_mandir}/man7
 install -m 0444 man/*.8.gz %{buildroot}%{_mandir}/man8
-install -m 0644 sbin/%{srvname}.in %{buildroot}%{_sbindir}/%{srvname}
+install -D -m 0644 sbin/%{srvname}.in %{buildroot}%{_sbindir}/%{srvname}
+install -d %{buildroot}%{_unitdir}
 install -m 0644 service/* %{buildroot}%{_unitdir}
+ln -s /usr/sbin/service %{buildroot}%{_sbindir}/rcsapping
+ln -s /usr/sbin/service %{buildroot}%{_sbindir}/rcsappong
+
 sed -i 's+@PYTHON@+%{_bindir}/python3+' %{buildroot}%{ocf_dir}/resource.d/suse/%{raname}
 sed -i 's+@PYTHON@+%{_bindir}/python3+' %{buildroot}%{_sbindir}/%{srvname}
 
@@ -85,18 +79,30 @@ sed -i 's+@PYTHON@+%{_bindir}/python3+' %{buildroot}%{_sbindir}/%{srvname}
 pytest tests
 %endif
 
+%pre
+%service_add_pre sapping.service sappong.service
+
+%post
+%service_add_post sapping.service sappong.service
+
+%preun
+%service_del_preun sapping.service sappong.service
+
+%postun
+%service_del_postun sapping.service sappong.service
+
 %files
 %defattr(-,root,root)
-%doc README.md
 %license LICENSE
+%doc README.md
 %{_mandir}/man7/*.7.gz
 %{_mandir}/man8/*.8.gz
 %dir %{ocf_dir}
 %dir %{ocf_dir}/resource.d
-%defattr(755,root,root,-)
 %dir %{ocf_dir}/resource.d/suse
-%{_sbindir}*
-%{ocf_dir}/resource.d/suse/*
+%defattr(755,root,root,-)
+%{ocf_dir}/resource.d/suse/%{raname}
+%{_sbindir}/*
 %defattr(644,root,root,-)
 %{_unitdir}/*
 

--- a/service/sapping.service
+++ b/service/sapping.service
@@ -6,8 +6,6 @@ Before=sapinit.service pacemaker.service
 [Service]
 Type=oneshot
 ExecStart=/usr/sbin/sapservices-move --hide
-StandardOutput=syslog
-StandardError=syslog
 
 [Install]
 WantedBy=multi-user.target

--- a/service/sappong.service
+++ b/service/sappong.service
@@ -6,8 +6,6 @@ After=sapinit.service
 [Service]
 Type=oneshot
 ExecStart=/usr/sbin/sapservices-move --unhide
-StandardOutput=syslog
-StandardError=syslog
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
remove deprecated option 'syslog' from the systemd service files (bsc#1185152)
add missing jsc#ECO-3341 reference to the changelog file as asked by maintenance
add systemd macros for pre/post/preun/postun scripts to the spec file
add the missing 'rcsapping' and 'rcsappong' symlink to the spec file