### PR TITLE
remove 'BuildRequire python3-mock' 

### DIFF
--- a/sapstartsrv-resource-agents.changes
+++ b/sapstartsrv-resource-agents.changes
@@ -1,8 +1,10 @@
 -------------------------------------------------------------------
-Tue Jul  5 15:32:26 UTC 2022 - abriel@suse.com
+Wed Sep 14 09:37:25 UTC 2022 - abriel@suse.com
 
 - Version bump to 0.9.1
 - man page updates based on customer feedback on conferences
+- remove 'BuildRequire python3-mock' as this is no longer needed
+  for the tests
 
 -------------------------------------------------------------------
 Fri Feb 25 11:18:02 UTC 2022 - abriel@suse.com

--- a/sapstartsrv-resource-agents.spec
+++ b/sapstartsrv-resource-agents.spec
@@ -34,7 +34,6 @@ Requires:       resource-agents
 Requires:       pacemaker > 1.1.1
 Requires:       python3
 %if %{with test}
-BuildRequires:  python3-mock
 BuildRequires:  python3-pytest
 %endif
 


### PR DESCRIPTION
as this is no longer needed for our tests and the package 'python3-mock' will be removed in the future.
This will fix issue https://github.com/SUSE/SAPStartSrv-resourceAgent/issues/34