### PR TITLE
ocf_suse_SAPStartSrv(7): REQUIREMENTS SAPInstance

### DIFF
--- a/man/SAPStartSrv_basic_cluster.7
+++ b/man/SAPStartSrv_basic_cluster.7
@@ -390,7 +390,7 @@ No output means default. See /etc/sysconfig/sbd for details.
 .PP
 \fB* show pacemaker service drop-in file\fR
 .PP
-In case systemd-style init is used for the HANA database, it might be desired
+In case systemd-style init is used for the SAP instance, it might be desired
 to have the  SAP instance service stopping after pacemaker at system shutdown.
 A drop-in file might help. Example SID is S07, instance number is 00.
 .PP

--- a/man/SAPStartSrv_basic_cluster.7
+++ b/man/SAPStartSrv_basic_cluster.7
@@ -133,18 +133,6 @@ subdaemons, while "yes" means fencing the node. Setting "yes" might help to avoi
 undefined situations.
 .br
 Optional, default no.
-.\" .PP
-.\" \fBpacemaker service dependency to SAP instance service\fR
-.\" .PP
-.\" \fB[Unit]\fR
-.\" .br
-.\" \fBWants=SAP${SID}_${INO}.service\fR
-.\" .br
-.\" \fBAfter=SAP${SID}_${INO}.service\fR
-.\" .PP
-.\" In case systemd-style init is used for the SAP instances, it might be desired
-.\" to have the SAP instance service stopping after pacemaker at system shutdown.
-.\" Therefor a drop-in file for the pacemaker service might help. See examples below.
 .PP
 .\"
 .SH EXAMPLES
@@ -389,26 +377,6 @@ No output means default. See /etc/sysconfig/sbd for details.
 .RS 2
 # grep "pacemaker-.*unresponsive.to.ipc" /var/log/messags
 .RE
-.\" .PP
-.\" \fB* show pacemaker service drop-in file\fR
-.\" .PP
-.\" In case systemd-style init is used for the SAP instance, it might be desired
-.\" to have the  SAP instance service stopping after pacemaker at system shutdown.
-.\" A drop-in file might help. Example SID is S07, instance number is 00.
-.\" .PP
-.\" .RS 2 
-.\" # cat /etc/systemd/system/pacemaker.service.d/00-pacemaker.conf
-.\" .br
-.\" [Unit]
-.\" .br 
-.\" Description=pacemaker needs SAP instance service 
-.\" .br
-.\" Documentation=man:SAPHanaSR_basic_cluster(7)
-.\" .br 
-.\" Wants=SAPS07_00.service
-.\" .br
-.\" After=SAPS07_00.service
-.\" .RE
 .PP
 \fB* check for pacemaker dependency to SAP instance service\fR
 .PP
@@ -446,10 +414,6 @@ filesystem table, for statically mounted NFS shares
 .TP
 /etc/systemd/system/SAP<SID>_<NR>.service
 systemd unit file for SAP instance
-.\" .TP
-.\" /etc/systemd/system/pacemaker.service.d/00-pacemaker.conf
-.\" drop-in file (optional)
-.\" TODO
 .PP
 .\"
 .SH BUGS

--- a/man/SAPStartSrv_basic_cluster.7
+++ b/man/SAPStartSrv_basic_cluster.7
@@ -122,7 +122,30 @@ to make this work. See ocf_suse_SAPStartSrv(7).
 The delay should be significantly greater than, or safely twice,
 pcmk_delay_max.
 .PP
-.\" TODO /etc/sysconfig/pacemaker PCMK_fail_fast=yes ?
+.\"
+\fB* Pacemaker basics
+.PP
+\fBPCMK_fail_fast = yes\fR
+.PP
+The parameter PCMK_fail_fast in /etc/sysconfig/pacemaker specifies how pacemaker
+reacts on failures of its subdaemons. Default "no" means to restart failed
+subdaemons, while "yes" means fencing the node. Setting "yes" might help to avoid
+undefined situations.
+.br
+Optional, default no.
+.PP
+\fBpacemaker service dependency to SAP instance service\fR
+.PP
+\fB[Unit]\fR
+.br
+\fBWants=SAP${SID}_${INO}.service\fR
+.br
+\fBAfter=SAP${SID}_${INO}.service\fR
+.PP
+In case systemd-style init is used for the SAP instances, it might be desired
+to have the SAP instance service stopping after pacemaker at system shutdown.
+Therefor a drop-in file for the pacemaker service might help. See examples below.
+.PP
 .\"
 .SH EXAMPLES
 .\" TODO OS network tcp_retries2=8 (8..10)
@@ -365,7 +388,39 @@ No output means default. See /etc/sysconfig/sbd for details.
 # grep "pacemaker-.*unresponsive.to.ipc" /var/log/messags
 .RE
 .PP
-\"
+\fB* show pacemaker service drop-in file\fR
+.PP
+In case systemd-style init is used for the HANA database, it might be desired
+to have the  SAP instance service stopping after pacemaker at system shutdown.
+A drop-in file might help. Example SID is S07, instance number is 00.
+.PP
+.RS 2
+# cat /etc/systemd/system/pacemaker.service.d/00-pacemaker.conf
+.br
+[Unit]
+.br 
+Description=pacemaker needs SAP instance service 
+.br
+Documentation=man:SAPHanaSR_basic_cluster(7)
+.br
+Wants=SAPS07_00.service
+.br
+After=SAPS07_00.service
+.RE
+.PP
+\fB* check for pacemaker dependency to SAP instance service\fR
+.PP
+Example SID is S07, instance number is 00.
+.PP
+.RS 2
+# systemctl show pacemaker.service | grep SAPS07_00
+.br
+# systemd-delta | grep pacemaker
+.br
+# systemd-analyze dot | grep "pacemaker.*SAPS07_00"
+.RE
+.PP
+.\"
 .SH FILES
 .\"
 .TP
@@ -389,6 +444,9 @@ filesystem table, for statically mounted NFS shares
 .TP
 /etc/systemd/system/SAP<SID>_<NR>.service
 systemd unit file for SAP instance
+.TP
+/etc/systemd/system/pacemaker.service.d/00-pacemaker.conf
+drop-in file (optional)
 .\" TODO
 .PP
 .\"

--- a/man/SAPStartSrv_basic_cluster.7
+++ b/man/SAPStartSrv_basic_cluster.7
@@ -133,18 +133,18 @@ subdaemons, while "yes" means fencing the node. Setting "yes" might help to avoi
 undefined situations.
 .br
 Optional, default no.
-.PP
-\fBpacemaker service dependency to SAP instance service\fR
-.PP
-\fB[Unit]\fR
-.br
-\fBWants=SAP${SID}_${INO}.service\fR
-.br
-\fBAfter=SAP${SID}_${INO}.service\fR
-.PP
-In case systemd-style init is used for the SAP instances, it might be desired
-to have the SAP instance service stopping after pacemaker at system shutdown.
-Therefor a drop-in file for the pacemaker service might help. See examples below.
+.\" .PP
+.\" \fBpacemaker service dependency to SAP instance service\fR
+.\" .PP
+.\" \fB[Unit]\fR
+.\" .br
+.\" \fBWants=SAP${SID}_${INO}.service\fR
+.\" .br
+.\" \fBAfter=SAP${SID}_${INO}.service\fR
+.\" .PP
+.\" In case systemd-style init is used for the SAP instances, it might be desired
+.\" to have the SAP instance service stopping after pacemaker at system shutdown.
+.\" Therefor a drop-in file for the pacemaker service might help. See examples below.
 .PP
 .\"
 .SH EXAMPLES
@@ -161,7 +161,7 @@ left out.
 This example has been taken from an ENSA2 three-node cluster SLE-HA 15 GA
 with diskless SBD:
 .PP
-.RS 4
+.RS 2 
 property cib-bootstrap-options: \\
 .br
  expected-quorum-votes=3 \\
@@ -201,7 +201,7 @@ This example has been taken from an ENSA2 two-node cluster SLE-HA 15 GA
 with disk-based SBD. An optional priority fecing is configured and the SBD
 pcmk_delay_max has been reduced:
 .PP
-.RS 4
+.RS 2
 primitive rsc_stonith_sbd stonith:external/sbd \\
 .br
  params pcmk_delay_max=15
@@ -243,6 +243,7 @@ Below is an examples of crm basic configuration for an ENSA1 two-node cluster on
 SLE 15. Shown are specific parameters which are needed. Some general parameters
 are left out.
 .PP
+.RS 2
 rsc_defaults rsc-options: \\
 .br
  resource-stickiness=1 \\
@@ -256,6 +257,7 @@ op_defaults op-options: \\
  timeout=600 \\
 .br
  record-pending=true
+.RE
 .PP
 \fB* crm simple SBD stonith configuration on SLE 16\fR
 .PP
@@ -263,7 +265,7 @@ The SBD STONITH/fencing mechanism on SLE-HA 16 uses fence_sbd instead of
 external/sbd. See manual page fence_sbd(8) for details. 
 Example for a basic disk-based SBD resource on SLE 16:
 .PP
-.RS 4
+.RS 2
 primitive rsc_stonith_sbd stonith:fence_sbd \\
 .br
  params pcmk-delay-max=15
@@ -278,7 +280,7 @@ multi-SID setups. The parent directory /usr/sap/ resides on each node locally.
 The file sapservices must not be shared between nodes.
 The correct mount options are depending on the NFS server.
 .PP
-.RS 1
+.RS 2 
 .\" TODO check NFS options
 nfs1:/s/EN2/sapmnt /sapmnt/EN2 nfs rw,hard,intr,nolock,actimeo=1,proto=tcp 0 0
 .br
@@ -301,7 +303,7 @@ targets. If at least two targets are reachable, the current node is preferred
 for running the ASCS. The maximum time for detecting connectivity changes is
 ca.180 seconds.
 .PP
-.RS 4
+.RS 2
 primitive rsc_ping ocf:pacemaker:ping \\
 .br
  op monitor interval=120 timeout=60 start-delay=10 on-fail=ignore \\
@@ -321,7 +323,7 @@ In case systemd style init is used for the SAP instance:
 saphostagent needs to be enabled and running, instance services need
 to be disabled. Example SID is HA1, instance number is 10.
 .PP
-.RS 4
+.RS 2
 # systemctl list-unit-files | grep -i sap
 .br
 # systemctl status SAPHA1_10.service
@@ -335,7 +337,7 @@ to be disabled. Example SID is HA1, instance number is 10.
 .PP
 Basic check for the saphostagent.
 .PP
-.RS 4
+.RS 2
 # /usr/sap/hostctrl/exe/saphostctrl -function Ping
 .br
 # /usr/sap/hostctrl/exe/saphostctrl -function ListInstances
@@ -346,7 +348,7 @@ Basic check for the saphostagent.
 Check the instance profile for HA specific settings.
 Example SID is EN2, instance number is 10.
 .PP
-.RS 4
+.RS 2
 # su - en2adm
 .br
 ~> sapcontrol -nr 10 -function GetStartProfile |\\
@@ -361,7 +363,7 @@ grep -e art_Program_ -e Autostart -e halib
 Check if the sidadm user is member of the HA specific haclient group.
 Example SID is EN2.
 .PP
-.RS 4
+.RS 2
 # groups en2adm
 .RE
 .PP
@@ -370,7 +372,7 @@ Example SID is EN2.
 No output means default, which is f.e. PCMK_fail_fast=no. See
 /etc/sysconfig/pacemakerd for details.
 .PP
-.RS 4
+.RS 2
 # cat /proc/$(pgrep pacemakerd)/environ | tr '\\0' '\\n' | grep PCMK_
 .RE
 .PP
@@ -378,35 +380,35 @@ No output means default, which is f.e. PCMK_fail_fast=no. See
 .PP
 No output means default. See /etc/sysconfig/sbd for details.
 .PP
-.RS 4
+.RS 2
 # cat /proc/$(pgrep pacemakerd)/environ | tr '\\0' '\\n' | grep SBD_
 .RE
 .PP
 \fB* check for pacemaker IPC timeouts
 .PP
-.RS 4
+.RS 2
 # grep "pacemaker-.*unresponsive.to.ipc" /var/log/messags
 .RE
-.PP
-\fB* show pacemaker service drop-in file\fR
-.PP
-In case systemd-style init is used for the SAP instance, it might be desired
-to have the  SAP instance service stopping after pacemaker at system shutdown.
-A drop-in file might help. Example SID is S07, instance number is 00.
-.PP
-.RS 2
-# cat /etc/systemd/system/pacemaker.service.d/00-pacemaker.conf
-.br
-[Unit]
-.br 
-Description=pacemaker needs SAP instance service 
-.br
-Documentation=man:SAPHanaSR_basic_cluster(7)
-.br
-Wants=SAPS07_00.service
-.br
-After=SAPS07_00.service
-.RE
+.\" .PP
+.\" \fB* show pacemaker service drop-in file\fR
+.\" .PP
+.\" In case systemd-style init is used for the SAP instance, it might be desired
+.\" to have the  SAP instance service stopping after pacemaker at system shutdown.
+.\" A drop-in file might help. Example SID is S07, instance number is 00.
+.\" .PP
+.\" .RS 2 
+.\" # cat /etc/systemd/system/pacemaker.service.d/00-pacemaker.conf
+.\" .br
+.\" [Unit]
+.\" .br 
+.\" Description=pacemaker needs SAP instance service 
+.\" .br
+.\" Documentation=man:SAPHanaSR_basic_cluster(7)
+.\" .br 
+.\" Wants=SAPS07_00.service
+.\" .br
+.\" After=SAPS07_00.service
+.\" .RE
 .PP
 \fB* check for pacemaker dependency to SAP instance service\fR
 .PP
@@ -444,9 +446,9 @@ filesystem table, for statically mounted NFS shares
 .TP
 /etc/systemd/system/SAP<SID>_<NR>.service
 systemd unit file for SAP instance
-.TP
-/etc/systemd/system/pacemaker.service.d/00-pacemaker.conf
-drop-in file (optional)
+.\" .TP
+.\" /etc/systemd/system/pacemaker.service.d/00-pacemaker.conf
+.\" drop-in file (optional)
 .\" TODO
 .PP
 .\"

--- a/man/ocf_suse_SAPStartSrv.7
+++ b/man/ocf_suse_SAPStartSrv.7
@@ -416,19 +416,20 @@ At least NW7.52 or SAP S/4HANA ABAP Platform 1909 for ENSA2.
 .PP
 * SAPInstance resource agent with MINIMAL_PROBE support, November 2020.
 .PP
-* Needed NFS shares (e.g. /sapmnt/$SID/, /usr/sap/$SID/) mounted statically or by automounter.
+* Needed NFS shares (e.g. /sapmnt/$SID/, /usr/sap/$SID/) mounted statically or
+by automounter.
 .PP
 .\" TODO discuss read-write vs. /var/.../sapservices.moved
 * Directory /usr/sap/ locally read-write mounted on each cluster node.
 .PP
 * Complete entries in /usr/sap/sapservices file.
 .PP
-* SAP instance profile Autostart feature is disabled for ASCS and ERS.
+* SAP instance profile Autostart feature is disabled for ASCS (SCS) and ERS.
 .PP
-* For ENSA2 (ENSA1) HA setups, the ASCS instance profile entry for the enqueue
-service _ENQ (_EN), Restart_Program_xx is replaced by Start_Program_xx. Same for
-the ERS instance profile entry for the enqueue replicator service _ENQR (_ER).
-Other services stay untouched. 
+* For ENSA2 (ENSA1) HA setups, the ASCS or SCS instance profile entry for the
+enqueue service _ENQ (_EN), Restart_Program_xx is replaced by Start_Program_xx.
+Same for the ERS instance profile entry for the enqueue replicator service _ENQR
+(_ER). Other services stay untouched. 
 .PP
 * The sapinit boot script does not read entries from sapservices file at boot.
 Thus services sapping and sappong to handle sapservices file at system boot.
@@ -448,9 +449,13 @@ The systemd enabled saphostagent and sapstartsrv is supported from
 sapstartsrv-resource-agents 0.9.1 onwards.
 An appropriate SAPInstance resource agent is needed, newer than November 2021.
 Please refer to the OS documentation for the systemd version.
-Please refer to SAP documentation for the SAP HANA version.
+Please refer to SAP documentation for the SAP software version.
 Combining systemd style hostagent with SystemV style instance is allowed.
 However, all nodes in one Linux cluster have to use the same style.
+.PP
+.\" TODO remove below, once fixed
+* The SAPInstance RA regularly checks systemd integration. The SAPInstance monitor
+interval might be increased to reduce side effects in Multi-SID setups.
 .PP
 * No firewall rules must block any needed port.
 .PP
@@ -459,7 +464,7 @@ However, all nodes in one Linux cluster have to use the same style.
 .\"
 .SH BUGS
 .\"
-The trace_ra resourcre tracing feature is not implemented so far.
+The trace_ra resource tracing feature is not implemented so far.
 .br
 In case of any problem, please use your favourite SAP support process to open a
 request for the component BC-OP-LNX-SUSE.


### PR DESCRIPTION
Hi,
ocf_suse_SAPStartSrv.7 now mentions in REQUIREMENTS the potential SAPInstance monitor effect on systemd.
Might be remove, once it is fixed. 
Might go into next maintenance update.
Regards,
Lars