### PR TITLE
bsc1221641 - Creating primitive for SAPStartSrv resource in SLES for 15 SP4 HA cluster results in monitor with timeout being added, asd well as start and stop timeouts

### DIFF
--- a/ra/SAPStartSrv.in
+++ b/ra/SAPStartSrv.in
@@ -356,8 +356,8 @@ class SapStartSrv(object):
         '''
         Is the sapstartsrv server process running?
         '''
-        self._inititialize()
         if ocf.is_probe():
+            self._inititialize()
             if self._get_status() == 0:
                 return ocf.OCF_SUCCESS
 
@@ -433,8 +433,7 @@ def main():
     sapstartsrv_agent.add_action(name='start', timeout=60, handler=sapstartsrv_instance.start)
     sapstartsrv_agent.add_action(name='stop', timeout=60, handler=sapstartsrv_instance.stop)
     sapstartsrv_agent.add_action(name='status', timeout=60, handler=sapstartsrv_instance.status)
-    sapstartsrv_agent.add_action(
-        name='monitor', timeout=20, interval=120, handler=sapstartsrv_instance.monitor)
+    sapstartsrv_agent.add_action(name='monitor', timeout=20, handler=sapstartsrv_instance.monitor)
     sapstartsrv_agent.add_action(
         name='validate-all', timeout=5, handler=sapstartsrv_instance.validate)
 

--- a/tests/SAPStartSrv_test.py
+++ b/tests/SAPStartSrv_test.py
@@ -849,9 +849,8 @@ class TestSAPStartSrv(unittest.TestCase):
         assert ocf_returncode == 0
 
         #if mock_is_probe:
-        if True:
-            self._agent._inititialize.assert_called_once_with()
-            self._agent._get_status.assert_called_once_with()
+        self._agent._inititialize.assert_called_once_with()
+        self._agent._get_status.assert_called_once_with()
 
     @mock.patch('ocf.OCF_SUCCESS', 0)
     @mock.patch('ocf.is_probe')

--- a/tests/SAPStartSrv_test.py
+++ b/tests/SAPStartSrv_test.py
@@ -862,7 +862,7 @@ class TestSAPStartSrv(unittest.TestCase):
         ocf_returncode = self._agent.monitor()
         assert ocf_returncode == 0
 
-        if not mock_is_probe:
+        if mock_is_probe:
             self._agent._inititialize.assert_called_once_with()
             assert self._agent._get_status.call_count == 0
 

--- a/tests/SAPStartSrv_test.py
+++ b/tests/SAPStartSrv_test.py
@@ -850,7 +850,7 @@ class TestSAPStartSrv(unittest.TestCase):
 
         if not mock_is_probe:
             self._agent._inititialize.assert_called_once_with()
-        self._agent._get_status.assert_called_once_with()
+            self._agent._get_status.assert_called_once_with()
 
     @mock.patch('ocf.OCF_SUCCESS', 0)
     @mock.patch('ocf.is_probe')

--- a/tests/SAPStartSrv_test.py
+++ b/tests/SAPStartSrv_test.py
@@ -862,8 +862,9 @@ class TestSAPStartSrv(unittest.TestCase):
         ocf_returncode = self._agent.monitor()
         assert ocf_returncode == 0
 
-        self._agent._inititialize.assert_called_once_with()
-        assert self._agent._get_status.call_count == 0
+        if not mock_is_probe:
+            self._agent._inititialize.assert_called_once_with()
+            assert self._agent._get_status.call_count == 0
 
     @mock.patch('ocf.OCF_SUCCESS', 0)
     def test_validate(self):

--- a/tests/SAPStartSrv_test.py
+++ b/tests/SAPStartSrv_test.py
@@ -849,7 +849,7 @@ class TestSAPStartSrv(unittest.TestCase):
         assert ocf_returncode == 0
 
         if not mock_is_probe:
-        self._agent._inititialize.assert_called_once_with()
+            self._agent._inititialize.assert_called_once_with()
         self._agent._get_status.assert_called_once_with()
 
     @mock.patch('ocf.OCF_SUCCESS', 0)

--- a/tests/SAPStartSrv_test.py
+++ b/tests/SAPStartSrv_test.py
@@ -862,7 +862,7 @@ class TestSAPStartSrv(unittest.TestCase):
         ocf_returncode = self._agent.monitor()
         assert ocf_returncode == 0
 
-        if mock_is_probe:
+        if not mock_is_probe:
             self._agent._inititialize.assert_called_once_with()
             assert self._agent._get_status.call_count == 0
 

--- a/tests/SAPStartSrv_test.py
+++ b/tests/SAPStartSrv_test.py
@@ -849,7 +849,7 @@ class TestSAPStartSrv(unittest.TestCase):
         assert ocf_returncode == 0
 
         #if mock_is_probe:
-        if true:
+        if True:
             self._agent._inititialize.assert_called_once_with()
             self._agent._get_status.assert_called_once_with()
 

--- a/tests/SAPStartSrv_test.py
+++ b/tests/SAPStartSrv_test.py
@@ -848,7 +848,7 @@ class TestSAPStartSrv(unittest.TestCase):
         ocf_returncode = self._agent.monitor()
         assert ocf_returncode == 0
 
-        if not mock_is_probe:
+        if mock_is_probe:
             self._agent._inititialize.assert_called_once_with()
             self._agent._get_status.assert_called_once_with()
 

--- a/tests/SAPStartSrv_test.py
+++ b/tests/SAPStartSrv_test.py
@@ -848,7 +848,8 @@ class TestSAPStartSrv(unittest.TestCase):
         ocf_returncode = self._agent.monitor()
         assert ocf_returncode == 0
 
-        if mock_is_probe:
+        #if mock_is_probe:
+        if true:
             self._agent._inititialize.assert_called_once_with()
             self._agent._get_status.assert_called_once_with()
 

--- a/tests/SAPStartSrv_test.py
+++ b/tests/SAPStartSrv_test.py
@@ -848,6 +848,7 @@ class TestSAPStartSrv(unittest.TestCase):
         ocf_returncode = self._agent.monitor()
         assert ocf_returncode == 0
 
+        if not mock_is_probe:
         self._agent._inititialize.assert_called_once_with()
         self._agent._get_status.assert_called_once_with()
 

--- a/tests/SAPStartSrv_test.py
+++ b/tests/SAPStartSrv_test.py
@@ -1106,7 +1106,7 @@ class TestSAPStartSrv(unittest.TestCase):
             mock.call(name='stop', timeout=60, handler=mock_sapstartrv_intance.stop),
             mock.call(name='status', timeout=60, handler=mock_sapstartrv_intance.status),
             mock.call(
-                name='monitor', timeout=20, interval=120, handler=mock_sapstartrv_intance.monitor),
+                name='monitor', timeout=20, handler=mock_sapstartrv_intance.monitor),
             mock.call(name='validate-all', timeout=5, handler=mock_sapstartrv_intance.validate),
         ])
 


### PR DESCRIPTION
ra/SAPStartSrv.in - removed misleading interval-value for the monitor-operation; monitor-method: move init to probe-only to save time for regular monitors (even if should be avoided)